### PR TITLE
Move bitcoinj files to a shadow path to prevent clashes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "money.terra"
-version = "0.20.3"
+version = "0.20.4"
 
 allprojects {
     apply {

--- a/wallet/src/jvmMain/java/shadow/org/bitcoinj/core/AddressFormatException.java
+++ b/wallet/src/jvmMain/java/shadow/org/bitcoinj/core/AddressFormatException.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package shadow.org.bitcoinj.core;
 
 public class AddressFormatException extends IllegalArgumentException {
     public AddressFormatException() {

--- a/wallet/src/jvmMain/java/shadow/org/bitcoinj/core/Bech32.java
+++ b/wallet/src/jvmMain/java/shadow/org/bitcoinj/core/Bech32.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package shadow.org.bitcoinj.core;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Locale;
 

--- a/wallet/src/jvmMain/kotlin/money/terra/util/Bech32.kt
+++ b/wallet/src/jvmMain/kotlin/money/terra/util/Bech32.kt
@@ -1,6 +1,6 @@
 package money.terra.util
 
-import org.bitcoinj.core.Bech32 as Bech32Lib
+import shadow.org.bitcoinj.core.Bech32 as Bech32Lib
 
 actual object Bech32 {
 


### PR DESCRIPTION
Hey guys! 👋 
We are having an issue using this library due to a clash on the package level. This is due to the package name. If you try to import this library into another project that also already imports the official bitcoinj package it will lead to undefined behaviour. 